### PR TITLE
Subgame solving from initial street node

### DIFF
--- a/ZippyEngine/Makefile
+++ b/ZippyEngine/Makefile
@@ -51,7 +51,7 @@ all:	bin/show_num_boards bin/show_boards bin/build_hand_value_tree bin/build_nul
 	bin/build_kmeans_buckets bin/crossproduct bin/prify bin/show_num_buckets \
 	bin/build_betting_tree bin/show_betting_tree bin/run_cfrp bin/run_tcfr bin/run_ecfr \
 	bin/run_rgbr bin/solve_all_subgames bin/solve_all_backup_subgames \
-	bin/solve_one_subgame_safe bin/solve_one_subgame_unsafe bin/progressively_solve_subgames \
+	bin/solve_one_subgame_safe bin/solve_one_subgame_unsafe  bin/solve_one_subgame_unsafe_nobase bin/progressively_solve_subgames \
 	bin/assemble_subgames bin/dump_file bin/show_preflop_strategy bin/show_preflop_reach_probs \
 	bin/show_probs_at_node bin/play bin/head_to_head bin/mc_node bin/eval_node bin/sampled_br \
 	bin/run_approx_rgbr bin/test_backup_tree bin/estimate_ram bin/find_gaps bin/keep_backups \
@@ -130,6 +130,10 @@ bin/solve_one_subgame_safe:	obj/solve_one_subgame_safe.o $(OBJS) $(HEADS)
 
 bin/solve_one_subgame_unsafe:	obj/solve_one_subgame_unsafe.o $(OBJS) $(HEADS)
 	g++ $(LDFLAGS) $(CFLAGS) -o bin/solve_one_subgame_unsafe obj/solve_one_subgame_unsafe.o \
+	$(OBJS) $(LIBRARIES)
+
+bin/solve_one_subgame_unsafe_nobase:	obj/solve_one_subgame_unsafe_nobase.o $(OBJS) $(HEADS)
+	g++ $(LDFLAGS) $(CFLAGS) -o bin/solve_one_subgame_unsafe_nobase obj/solve_one_subgame_unsafe_nobase.o \
 	$(OBJS) $(LIBRARIES)
 
 bin/progressively_solve_subgames:	obj/progressively_solve_subgames.o $(OBJS) $(HEADS)

--- a/ZippyEngine/runs/cfrps_params
+++ b/ZippyEngine/runs/cfrps_params
@@ -5,4 +5,4 @@ NNR true
 RegretFloors 0,0,0,0
 RegretScaling 16,16,16,16
 SumprobScaling 16,16,16,16
-SoftWarmup 100
+SoftWarmup 200

--- a/ZippyEngine/src/betting_abstraction.cpp
+++ b/ZippyEngine/src/betting_abstraction.cpp
@@ -13,6 +13,11 @@
 using std::string;
 using std::vector;
 
+/*
+  Bet sizes seperated by ',', per bet (up to MaxBets) seperated by ';' and streets seperated by '|' 
+  Bet sizes given as decimal fraction of pot.
+  --Jon
+*/
 static void ParseBetSizes(const string &param_value,
 			  vector<vector<vector<double> > > *bet_sizes) {
   vector<string> v1;
@@ -44,7 +49,10 @@ static void ParseBetSizes(const string &param_value,
     }
   }
 }
-
+/*
+  Parse BetSizeMultipliers. Multipliers are not used.
+  --Jon
+*/
 static void ParseMultipliers(const string &param_value, vector<vector<double> > *multipliers) {
   vector<string> v1;
   Split(param_value.c_str(), '|', true, &v1);
@@ -69,6 +77,10 @@ static void ParseMultipliers(const string &param_value, vector<vector<double> > 
   }
 }
 
+/*
+  Parse 'MaxBets': maximimum number of bets per street (comma sereprated integers).
+  --Jon
+*/
 static void ParseMaxBets(const Params &params, const string &param, vector<int> *max_bets) {
   if (! params.IsSet(param.c_str())) {
     fprintf(stderr, "%s must be set\n", param.c_str());
@@ -89,6 +101,13 @@ static void ParseMaxBets(const Params &params, const string &param, vector<int> 
   }
 }
 
+/*
+  Parse 'MinBets': bets per street which MUST be minimum bets.
+  Street seperated by ';' and bet seperated by ','.
+  For exmaple on a 2 street game: '0,1;0,2' would imply the first two bets 
+  on the first street and the first and third bet on the second street MUST be minbets.
+  --Jon
+*/
 void BettingAbstraction::ParseMinBets(const string &value, vector< vector<bool> > *min_bets) {
   int max_street = Game::MaxStreet();
   vector<string> v1;
@@ -123,6 +142,11 @@ void BettingAbstraction::ParseMinBets(const string &value, vector< vector<bool> 
   }
 }
 
+/* 
+  Parse merge rules (i.e. ReentrantBetSizes)
+  TODO:Not sure about reentrant stuff yet
+  --Jon
+*/
 static void ParseMergeRules(const string &value, vector< vector<int> > *merge_rules) {
   int max_street = Game::MaxStreet();
   int num_players = Game::NumPlayers();
@@ -155,6 +179,11 @@ static void ParseMergeRules(const string &value, vector< vector<int> > *merge_ru
   }
 }
 
+/*
+  Populate BettingAbstraction from betting_abstraction_params
+  See betting_abstraction_params.cpp for description of params
+  --Jon
+*/
 BettingAbstraction::BettingAbstraction(const Params &params) {
   betting_abstraction_name_ = params.GetStringValue("BettingAbstractionName");
   limit_ = params.GetBooleanValue("Limit");

--- a/ZippyEngine/src/betting_abstraction_params.cpp
+++ b/ZippyEngine/src/betting_abstraction_params.cpp
@@ -8,50 +8,113 @@
 #include "params.h"
 
 using std::unique_ptr;
-
+/*
+  Param file definition for a betting abstraction
+    BettingAbstractionName
+        Required, name for given betting abstraction
+    Limit
+        Required, bool: is limit game?
+    StackSize
+        Required, stack size in BB
+    MinBet
+        Required, minimum bet size in bb (applies to all streets)
+    InitialStreet
+        Optional, starting street (defaults to 0)
+    Asymmetric
+        Required, bool: is betting the same for both players
+        If false, use Our{PARAM} and Opp{PARAM} 
+    NoLimitTreeType
+        Required, deprecated: used to switch between CreateNoLimitTree1 and CreateNoLimitTree2.
+        Now CreateMPTree is always used.
+    MaxBets (Asymmetric option)
+        Required, max number of bets per player per street
+    BetSizes (Asymmetric option)
+        Required, bet size options per street given as decimal fraction of pot.
+        Street seperated by '|', bet seperated by ';' bet size seperated by ','
+        For example: in a two street game with 50% open and 75% and 150% 3bet preflop, and 
+        25%, 50%, 75% postflop with 50% 3bet: '0.5;0.75,1.5|0.25,0.5,0.75;0.5'
+        WARNING: Bet sizes must be specified for each bet up to MaxBets[street]!    
+    AlwaysAllIn (Asymmetric option)
+        Required, bool: add all in option at every node of betting tree
+    MinBets (Asymmetric option) // perhaps deprecated (i.e. has no effect)
+        Optional, bets per street which must be minbets. Streets seperated by ';'
+        and bet number seperated by ','. For exmaple on a 2 street game: '0,1;0,2'
+        would imply the first two bets on the first street and the first and third
+        bet on the second street MUST be minbets. Bet number must be less than MaxBets 
+        WARNING: the setting is not used in any of the example runs.
+    MinAllInPot // not used
+    NoOpenLimp // probably deprecated, not used in any runs
+    NoRegularBetThreshold // not used
+    OurOnlyPotThreshold // not used in any runs. would specify pot size
+                           threshold after which we only use pot size bets
+    GeometricType // not used
+    CloseToAllInFrac
+        Optional, if bet would make pot larger than CloseToAllInFrac * size of all in pot,
+        go all in instead. E.g CloseToAllInFrac = 0.5: any bet that would make pot larger
+        than our stack size, go all in instead.
+    BetSizeMultipliers // not used
+    AllowableBetTos // not used in any runs
+    LastAggressorKey // not used
+    TODO:not sure about reentrant stuff yet.
+  --Jon
+*/
 unique_ptr<Params> CreateBettingAbstractionParams(void) {
   unique_ptr<Params> params(new Params());
   params->AddParam("BettingAbstractionName", P_STRING);
   params->AddParam("Limit", P_BOOLEAN);
   params->AddParam("StackSize", P_INT);
+  params->AddParam("MinBet", P_INT);
+  params->AddParam("InitialStreet", P_INT);
+  params->AddParam("Asymmetric", P_BOOLEAN);
+  params->AddParam("NoLimitTreeType", P_INT);
+
   params->AddParam("MaxBets", P_STRING);
   params->AddParam("OurMaxBets", P_STRING);
   params->AddParam("OppMaxBets", P_STRING);
+
   params->AddParam("BetSizes", P_STRING);
   params->AddParam("OurBetSizes", P_STRING);
-  params->AddParam("OppBetSizes", P_STRING);
-  params->AddParam("MinBet", P_INT);
+  params->AddParam("OppBetSizes", P_STRING);  
+
+  // Deprecated
   params->AddParam("AllBetSizeStreets", P_STRING);
   params->AddParam("AllEvenBetSizeStreets", P_STRING);
-  params->AddParam("NoLimitTreeType", P_INT);
-  params->AddParam("InitialStreet", P_INT);
-  params->AddParam("Asymmetric", P_BOOLEAN);
+
   params->AddParam("AlwaysAllIn", P_BOOLEAN);
   params->AddParam("OurAlwaysAllIn", P_BOOLEAN);
   params->AddParam("OppAlwaysAllIn", P_BOOLEAN);
+
   params->AddParam("MinBets", P_STRING);
   params->AddParam("OurMinBets", P_STRING);
   params->AddParam("OppMinBets", P_STRING);
+
   params->AddParam("MinAllInPot", P_INT);
   params->AddParam("NoOpenLimp", P_BOOLEAN);
   params->AddParam("OurNoOpenLimp", P_BOOLEAN);
   params->AddParam("OppNoOpenLimp", P_BOOLEAN);
+
   params->AddParam("NoRegularBetThreshold", P_INT);
   params->AddParam("OurNoRegularBetThreshold", P_INT);
   params->AddParam("OppNoRegularBetThreshold", P_INT);
+
   params->AddParam("OnlyPotThreshold", P_INT);
   params->AddParam("OurOnlyPotThreshold", P_INT);
   params->AddParam("OppOnlyPotThreshold", P_INT);
+
   params->AddParam("GeometricType", P_INT);
   params->AddParam("OurGeometricType", P_INT);
   params->AddParam("OppGeometricType", P_INT);
+
   params->AddParam("CloseToAllInFrac", P_DOUBLE);
   params->AddParam("OurBetSizeMultipliers", P_STRING);
   params->AddParam("OppBetSizeMultipliers", P_STRING);
+
+  // not sure about reentrant stuff yet
   params->AddParam("ReentrantStreets", P_STRING);
   params->AddParam("BettingKeyStreets", P_STRING);
   params->AddParam("MinReentrantPot", P_INT);
   params->AddParam("MergeRules", P_STRING);
+
   params->AddParam("AllowableBetTos", P_STRING);
   params->AddParam("LastAggressorKey", P_BOOLEAN);
 

--- a/ZippyEngine/src/cards.cpp
+++ b/ZippyEngine/src/cards.cpp
@@ -86,7 +86,7 @@ void OutputTwoCards(Card c1, Card c2) {
 }
 
 void OutputTwoCards(const Card *cards) {
-  OutputTwoCards(cards[0], cards[1]);
+  OutputTwoCards(cards[0], cards[1]);  
 }
 
 void OutputThreeCards(Card c1, Card c2, Card c3) {
@@ -171,11 +171,16 @@ void OutputSevenCards(const Card *cards) {
 		   cards[6]);
 }
 
-void OutputNCards(const Card *cards, int n) {
+void OutputNCards(const Card *cards, int n, bool newline) {
   for (int i = 0; i < n; ++i) {
     if (i > 0) printf(" ");
     OutputCard(cards[i]);
   }
+  if (newline) printf("\n");
+}
+
+void OutputNCards(const Card *cards, int n) {
+  OutputNCards(cards, n, false);
 }
 
 Card MakeCard(int rank, int suit) {

--- a/ZippyEngine/src/cards.h
+++ b/ZippyEngine/src/cards.h
@@ -29,6 +29,7 @@ void OutputSevenCards(Card c1, Card c2, Card c3, Card c4, Card c5,
 		      Card c6, Card c7);
 void OutputSevenCards(const Card *cards);
 void OutputNCards(const Card *cards, int n);
+void OutputNCards(const Card *cards, int n, bool newline);
 Card ParseCard(const char *str);
 void ParseTwoCards(const char *str, bool space_separated, Card *cards);
 void ParseThreeCards(const char *str, bool space_separated, Card *cards);

--- a/ZippyEngine/src/reach_probs.cpp
+++ b/ZippyEngine/src/reach_probs.cpp
@@ -1,7 +1,15 @@
 #include <stdio.h>
 #include <stdlib.h>
 
+#include <iostream>
+#include <fstream>
+#include <sstream>
 #include <memory>
+#include <string>
+#include <algorithm> 
+#include <functional> 
+#include <cctype>
+#include <locale>
 
 #include "board_tree.h"
 #include "buckets.h"
@@ -11,9 +19,31 @@
 #include "game.h"
 #include "hand_tree.h"
 #include "reach_probs.h"
+#include "files.h"
+#include "split.h"
 
 using std::shared_ptr;
 using std::unique_ptr;
+using std::string;
+
+// trim from start (in place)
+static inline void ltrim(std::string &s) {
+    s.erase(s.begin(), std::find_if(s.begin(), s.end(),
+            std::not1(std::ptr_fun<int, int>(std::isspace))));
+}
+
+// trim from end (in place)
+static inline void rtrim(std::string &s) {
+    s.erase(std::find_if(s.rbegin(), s.rend(),
+            std::not1(std::ptr_fun<int, int>(std::isspace))).base(), s.end());
+}
+
+// trim from both ends (in place)
+static inline void trim(std::string &s) {
+    ltrim(s);
+    rtrim(s);
+}
+
 
 ReachProbs::ReachProbs(void) {
   int num_players = Game::NumPlayers();
@@ -42,6 +72,88 @@ ReachProbs *ReachProbs::CreateRoot(void) {
   }
   return reach_probs;
 }
+
+void AddHandsToReachProb(ReachProbs *reach_probs, string &hands, double prob, int p) {
+  std::vector<string> v1;
+  int max_card1 = Game::MaxCard() + 1;
+  Card cards[2];
+  Split(hands.c_str(), ',', false, &v1);
+  for (string &hand : v1)
+  {  
+      trim(hand);
+      ParseTwoCards(hand.c_str(), false, cards);      
+      int enc = cards[0] * max_card1 + cards[1];
+      reach_probs->Set(p, enc, prob);
+  }  
+}
+
+/* Load static/ip.txt and static/oop.txt (CrEV format) -- Jon */
+ReachProbs *ReachProbs::Load(void) {
+  ReachProbs *reach_probs = new ReachProbs();
+  int num_players = Game::NumPlayers();
+  int max_card1 = Game::MaxCard() + 1;
+  for (int p = 0; p < num_players; ++p) {
+    reach_probs->Allocate(p);
+    for (Card hi = 1; hi < max_card1; ++hi) {
+      for (Card lo = 0; lo < hi; ++lo) {
+        int enc = hi * max_card1 + lo;
+        reach_probs->Set(p, enc, 0.0);
+      }
+    }
+  }
+  char ip_dir[500];
+  char oop_dir[500];
+  sprintf(ip_dir, "%s/ip.txt", Files::StaticBase());
+  sprintf(oop_dir, "%s/oop.txt", Files::StaticBase());
+  // TODO: parse ip and oop here
+  // oop p = 0
+  for (int p = 0; p < num_players; p++) {
+    char* dir = p == 0 ? oop_dir : ip_dir;
+    std::ifstream f(dir);
+    string fstr;
+    if (f) {
+      std::ostringstream ss;
+      ss << f.rdbuf();
+      fstr = ss.str();
+    }
+    int len = fstr.length();
+    int i = 0;
+    int j = 0;
+    while (true) {
+      j = i + 2;
+      while (i < len && fstr[i] != '[') ++i;
+      if (i == len) {      
+        string hands(fstr, j, len - j);     
+        AddHandsToReachProb(reach_probs, hands, 1.0, p);
+        break;
+      }
+      int j = i + 1;
+      while (i < len && fstr[i] != ']') ++i;
+      string tag(fstr, j, i - j);
+      double v;
+      if (sscanf(tag.c_str(), "%lf", &v) != 1) {
+        fprintf(stderr, "Couldn't parse double value: %s\n",
+          tag.c_str());
+        exit(-1);
+      }
+      v /= 100;
+      // tag = "[/" + tag + "]";
+      // std::cout << tag << std::endl;
+      j = i + 1;
+      while (i < len && fstr[i] != '[') ++i;    
+      string hands(fstr, j, i - j);
+      AddHandsToReachProb(reach_probs, hands, v, p);    
+      while (i < len && fstr[i] != ']') ++i;
+      if (i + 3 >= len)
+        break;
+
+      //exit(-1);
+      // Strip any trailing \n
+    }    
+  }
+  return reach_probs;
+}
+
 
 shared_ptr<ReachProbs []> ReachProbs::CreateSuccReachProbs(Node *node, int gbd, int lbd,
 							   const CanonicalCards *hands,

--- a/ZippyEngine/src/reach_probs.h
+++ b/ZippyEngine/src/reach_probs.h
@@ -12,6 +12,7 @@ class ReachProbs {
 public:
   ~ReachProbs(void) {}
   static ReachProbs *CreateRoot(void);
+  static ReachProbs *Load(void);
   static std::shared_ptr<ReachProbs []> CreateSuccReachProbs(Node *node, int gbd, int lbd,
 							     const CanonicalCards *hands,
 							     const Buckets &buckets,

--- a/ZippyEngine/src/solve_one_subgame_unsafe_nobase.cpp
+++ b/ZippyEngine/src/solve_one_subgame_unsafe_nobase.cpp
@@ -1,0 +1,273 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include <memory>
+#include <string>
+#include <unordered_set>
+#include <vector>
+
+#include "betting_abstraction.h"
+#include "betting_abstraction_params.h"
+#include "betting_tree_builder.h"
+#include "betting_tree.h"
+#include "betting_trees.h"
+#include "board_tree.h"
+#include "buckets.h"
+#include "cards.h"
+#include "canonical_cards.h"
+#include "card_abstraction.h"
+#include "card_abstraction_params.h"
+#include "cfr_config.h"
+#include "cfr_params.h"
+#include "cfr_utils.h"
+#include "cfr_values.h"
+#include "eg_cfr.h"
+#include "files.h"
+#include "game.h"
+#include "game_params.h"
+#include "hand_tree.h"
+#include "hand_value_tree.h"
+#include "io.h"
+#include "params.h"
+#include "reach_probs.h"
+#include "split.h"
+#include "subgame_utils.h" // CreateSubtrees()
+#include "unsafe_eg_cfr.h"
+#include "vcfr.h"
+
+using std::shared_ptr;
+using std::string;
+using std::unique_ptr;
+using std::unordered_set;
+using std::vector;
+
+class SubgameSolver {
+public:
+  SubgameSolver(const CardAbstraction &card_abstraction,
+                const BettingAbstraction &betting_abstraction,
+                const CFRConfig &cfr_config, const Buckets &buckets,
+                int solve_st, int pot_size,
+                int target_bd, bool quantize,
+                int num_subgame_its, int num_threads);
+  void Solve(const ReachProbs &reach_probs);
+private:  
+  void Checkpoint(int it, UnsafeEGCFR* eg_cfr, Node* root);
+  const CardAbstraction &card_abstraction_;
+  const BettingAbstraction &betting_abstraction_;
+  const CFRConfig &cfr_config_;
+  const Buckets &buckets_;
+  unique_ptr<BettingTrees> base_betting_trees_;
+  int target_bd_;
+  int solve_st_;
+  int pot_size_;
+  int num_subgame_its_;
+  int num_threads_;
+};
+
+void Show(Node *node, const string &action_sequence, int target_p, const Buckets &buckets,
+   const CFRValues &values, const CanonicalCards *hands) {
+  // Initialize to -1 because we want to increment at the top of the loop below.
+  int nt = node->NonterminalID();
+  int st = node->Street();
+  int pa = node->PlayerActing();
+  int num_succs = node->NumSuccs();
+  int hcp = -1;
+  int dsi = node->DefaultSuccIndex();  
+  AbstractCFRStreetValues *street_values = values.StreetValues(st);
+  CFRStreetValues<double> *d_street_values;
+  CFRStreetValues<int> *i_street_values;
+  int *i_values = nullptr;
+  double *d_values = nullptr;
+  if ((d_street_values =
+  dynamic_cast<CFRStreetValues<double> *>(street_values))) {
+    d_values = d_street_values->AllValues(pa, nt);
+  } else {
+    i_street_values = dynamic_cast<CFRStreetValues<int> *>(street_values);
+    i_values = i_street_values->AllValues(pa, nt);
+  }  
+  unordered_set<int> seen_buckets;
+  int num_hole_card_pairs = Game::NumHoleCardPairs(2);  
+  for (int i = 0; i < num_hole_card_pairs; ++i) {
+    const Card *cards = hands->Cards(i);
+    ++hcp;
+    int offset, b = -1;
+    if (buckets.None(st)) {
+      offset = hcp * num_succs;
+    } else {
+      b = buckets.Bucket(st, hcp);
+      if (seen_buckets.find(b) != seen_buckets.end()) {
+        // fprintf(stderr, "hi %i lo %i b %i\n", hi, lo, b);
+        continue;
+      }
+      seen_buckets.insert(b);
+      offset = b * num_succs;
+    }
+    if (action_sequence == "") {
+      printf("Root ");
+    } else {
+      printf("%s ", action_sequence.c_str());
+    }
+    OutputTwoCards(cards);
+    double sum = 0;
+    if (i_values) {
+      for (int s = 0; s < num_succs; ++s) {
+        int iv = i_values[offset + s];
+        if (iv > 0) sum += iv;
+      }
+    } else {
+      for (int s = 0; s < num_succs; ++s) {
+        double dv = d_values[offset + s];
+        if (dv > 0) sum += dv;
+      }
+    }
+    if (sum == 0) {
+      for (int s = 0; s < num_succs; ++s) {
+        printf(" %f", s == dsi ? 1.0 : 0);
+      }
+    } else {
+      for (int s = 0; s < num_succs; ++s) {
+        if (i_values) {
+          int iv = i_values[offset + s];
+          printf(" %s:%.2f ", node->ActionName(s).c_str(), iv > 0 ? 100 * iv / sum : 0);
+        } else {
+          double dv = d_values[offset + s];
+          printf(" %s:%.2f", node->ActionName(s).c_str(), dv > 0 ? 100 * dv / sum : 0);
+        }
+      }
+    }
+    if (! buckets.None(st)) {
+      printf(" (b %u)", b);
+    }
+    printf(" (pa %u nt %u)\n", node->PlayerActing(), node->NonterminalID());
+    fflush(stdout);
+  }  
+}
+
+SubgameSolver::SubgameSolver(const CardAbstraction &card_abstraction,
+                             const BettingAbstraction &betting_abstraction,
+                             const CFRConfig &cfr_config, const Buckets &buckets,
+                             int solve_st, int pot_size,
+                             int target_bd, bool quantize,
+                             int num_subgame_its, int num_threads) :
+  card_abstraction_(card_abstraction),
+  betting_abstraction_(betting_abstraction),
+  cfr_config_(cfr_config), buckets_(buckets),
+  target_bd_(target_bd) {
+  num_subgame_its_ = num_subgame_its;
+  num_threads_ = num_threads;
+  solve_st_ = solve_st;
+  pot_size_ = pot_size;
+  
+  const Card *board = BoardTree::Board(solve_st_, target_bd_);
+  //
+  fprintf(stderr, "Resolve st %i gbd %i\n", solve_st, target_bd_);  
+  OutputNCards(board, solve_st+2);  
+}
+
+// Currently assume that this is a street-initial node.
+// Might need to do up to four solves.  Imagine we have an asymmetric base
+// betting tree, and an asymmetric solving method.
+void SubgameSolver::Solve(const ReachProbs &reach_probs) {  
+  int st = solve_st_;  
+  int num_players = Game::NumPlayers();
+  HandTree hand_tree(st, target_bd_, Game::MaxStreet());
+  UnsafeEGCFR eg_cfr(card_abstraction_, card_abstraction_,
+		     betting_abstraction_, cfr_config_, cfr_config_,
+		     buckets_, num_threads_);
+  if (st < Game::MaxStreet()) {
+    eg_cfr.SetSplitStreet(st + 1);
+  }
+  
+  int num_asym_players = betting_abstraction_.Asymmetric() ? num_players : 1;
+  for (int asym_p = 0; asym_p < num_asym_players; ++asym_p) {
+    unique_ptr<BettingTrees> subgame_subtrees(CreateSubtrees(st, Game::FirstToAct(st), pot_size_ / 2, asym_p, betting_abstraction_));
+    // Print tree::
+    //subgame_subtrees.get()->GetBettingTree()->Display();
+
+    double resolving_secs = 0;
+    struct timespec start, finish;
+    clock_gettime(CLOCK_MONOTONIC, &start);
+    // One solve for unsafe endgame solving, no t_vals
+    eg_cfr.SolveSubgame(subgame_subtrees.get(), target_bd_, reach_probs, "",
+			 &hand_tree, nullptr, -1, true, num_subgame_its_);
+    clock_gettime(CLOCK_MONOTONIC, &finish);
+    resolving_secs += (finish.tv_sec - start.tv_sec);
+    resolving_secs += (finish.tv_nsec - start.tv_nsec) / 1000000000.0;
+    printf("Resolving secs: %f\n", resolving_secs);
+    fflush(stdout);        
+        
+    Node* rootNode = subgame_subtrees.get()->Root();    
+    // Print out root strategy:
+    CFRValues* values = eg_cfr.Sumprobs().get();
+    Show(rootNode, "", 0, buckets_, *values, hand_tree.Hands(st, target_bd_));
+    // Save strategy
+    Checkpoint(0, &eg_cfr, rootNode);
+  }
+}
+
+void SubgameSolver::Checkpoint(int it, UnsafeEGCFR* eg_cfr, Node* root) {
+  char dir[500];
+  sprintf(dir, "%s/%s.%u.%s.%u.%u.%u.%s.%s", Files::NewCFRBase(),
+	  Game::GameName().c_str(), Game::NumPlayers(),
+	  card_abstraction_.CardAbstractionName().c_str(), Game::NumRanks(),
+	  Game::NumSuits(), Game::MaxStreet(), betting_abstraction_.BettingAbstractionName().c_str(),
+	  cfr_config_.CFRConfigName().c_str());
+  // if (betting_abstraction_.Asymmetric()) {
+  //   char buf[100];
+  //   sprintf(buf, ".p%u", target_p_);
+  //   strcat(dir, buf);
+  // }
+  Mkdir(dir);
+  eg_cfr->Regrets().get()->Write(dir, it, root, "x", -1, false);
+  eg_cfr->Sumprobs().get()->Write(dir, it, root, "x", -1, true);
+}
+
+static void Usage(const char *prog_name) {
+  fprintf(stderr, "USAGE: %s <game params> <card params> <betting params> <CFR params> "
+                  "<initial street> <pot size> <bd> <its> [quantize|raw] <num threads>\n",
+	  prog_name);
+  exit(-1);
+}
+
+int main(int argc, char *argv[]) {
+  if (argc != 11) Usage(argv[0]);
+  Files::Init();
+  unique_ptr<Params> game_params = CreateGameParams();
+  game_params->ReadFromFile(argv[1]);
+  Game::Initialize(*game_params);
+  unique_ptr<Params> card_params = CreateCardAbstractionParams();
+  card_params->ReadFromFile(argv[2]);
+  unique_ptr<CardAbstraction>
+    card_abstraction(new CardAbstraction(*card_params));
+  unique_ptr<Params> betting_params = CreateBettingAbstractionParams();
+  betting_params->ReadFromFile(argv[3]);
+  unique_ptr<BettingAbstraction>
+    betting_abstraction(new BettingAbstraction(*betting_params));
+  unique_ptr<Params> cfr_params = CreateCFRParams();
+  cfr_params->ReadFromFile(argv[4]);
+  unique_ptr<CFRConfig> cfr_config(new CFRConfig(*cfr_params));
+  int st, pot_size, bd, its;
+  if (sscanf(argv[5], "%i", &st) != 1)        Usage(argv[0]);
+  if (sscanf(argv[6], "%i", &pot_size) != 1)  Usage(argv[0]);
+  if (sscanf(argv[7], "%i", &bd) != 1)        Usage(argv[0]);
+  if (sscanf(argv[8], "%i", &its) != 1)       Usage(argv[0]);
+  string q = argv[9];
+  bool quantize;
+  if (q == "quantize") quantize = true;
+  else if (q == "raw") quantize = false;
+  else                 Usage(argv[0]);
+  int num_threads;
+  if (sscanf(argv[10], "%i", &num_threads) != 1) Usage(argv[0]);
+
+  Buckets buckets(*card_abstraction, false);
+  BoardTree::Create();
+  BoardTree::CreateLookup();
+  HandValueTree::Create();
+
+  SubgameSolver solver(*card_abstraction, *betting_abstraction, *cfr_config,
+		       buckets, st, pot_size, bd, quantize, its, num_threads);
+
+  unique_ptr<ReachProbs>  reach_probs(ReachProbs::Load());
+  solver.Solve(*reach_probs);
+}

--- a/ZippyEngine/src/subgame_utils.cpp
+++ b/ZippyEngine/src/subgame_utils.cpp
@@ -44,14 +44,22 @@ using std::vector;
 BettingTrees *CreateSubtrees(int st, int player_acting, int last_bet_to, int target_p,
 			     const BettingAbstraction &betting_abstraction) {
   // Assume subtree rooted at street-initial node
+  int num_players = Game::NumPlayers();
   int last_bet_size = 0;
   int num_street_bets = 0;
+  int num_bets = 0;  
   BettingTreeBuilder betting_tree_builder(betting_abstraction, target_p);
+  string key;  
   int num_terminals = 0;
-  // Should call routine from mp_betting_tree.cpp instead
+  int num_players_to_act = 2;
+  unique_ptr<bool []> folded(new bool[num_players]);
+  for (int p = 0; p < num_players; ++p) folded[p] = false;
+  // Should call routine from mp_betting_tree.cpp instead // DONE : -- Jon
   shared_ptr<Node> subtree_root =
-    betting_tree_builder.CreateNoLimitSubtree(st, last_bet_size, last_bet_to, num_street_bets,
-					      player_acting, target_p, &num_terminals);
+    betting_tree_builder.CreateMPSubtree(st, last_bet_size, last_bet_to, num_street_bets,
+					 num_bets, player_acting, num_players_to_act, folded.get(), target_p, &key, &num_terminals);
+    
+                
   // Delete the nodes under subtree_root?  Or does garbage collection
   // automatically take care of it because they are shared pointers.
   return new BettingTrees(subtree_root.get());

--- a/ZippyEngine/src/unsafe_eg_cfr.cpp
+++ b/ZippyEngine/src/unsafe_eg_cfr.cpp
@@ -46,7 +46,7 @@ void UnsafeEGCFR::SolveSubgame(BettingTrees *subtrees, int solve_bd, const Reach
 
   for (it_ = 1; it_ <= num_its; ++it_) {
     // Go from high to low to mimic slumbot2017 code
-    for (int p = (int)num_players - 1; p >= 0; --p) {
+    for (int p = (int)num_players - 1; p >= 0; --p) {    
       HalfIteration(subtrees, p, reach_probs.Get(p^1), hand_tree, action_sequence);
     }
   }

--- a/ZippyEngine/src/vcfr.h
+++ b/ZippyEngine/src/vcfr.h
@@ -55,6 +55,7 @@ class VCFR {
 						    const HandTree *hand_tree,
 						    const std::string &action_sequence);
   std::shared_ptr<CFRValues> Sumprobs(void) const {return sumprobs_;}
+  std::shared_ptr<CFRValues> Regrets(void) const {return regrets_;}
   void SetSumprobs(std::shared_ptr<CFRValues> &src) {sumprobs_ = src;}
   void SetRegrets(std::shared_ptr<CFRValues> &src) {regrets_ = src;}
   void ClearSumprobs(void) {sumprobs_.reset();}


### PR DESCRIPTION
Added solve_one_subgame_unsafe_nobase for solving of subgame from given street and board.
Ranges are loaded from static/ip.txt and static/oop.txt.

Only tested / assumed working with Symmetric betting abstractions.

Also commented betting_abstraction_params and betting_abstraction